### PR TITLE
feat(backend): validate foreign key references on creation

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,6 +1,6 @@
 from collections.abc import Generator
 from typing import Annotated
-from fastapi import Depends
+from fastapi import Depends, HTTPException
 from sqlmodel import Session
 from app.core.db import engine
 
@@ -11,3 +11,16 @@ def get_db() -> Generator[Session, None, None]:
 
 
 SessionDep = Annotated[Session, Depends(get_db)]
+
+
+def validate_fk_exists(
+    session: Session, model: type, fk_value: int | None, fk_name: str
+) -> None:
+    """Validate that a foreign key exists in the target table."""
+    if fk_value is None:
+        return
+    if not session.get(model, fk_value):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid foreign key '{fk_name}': record with ID {fk_value} does not exist.",
+        )

--- a/backend/app/api/routes/alert.py
+++ b/backend/app/api/routes/alert.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter, HTTPException
 from typing import Optional, Literal
 from sqlmodel import select
-from app.api.deps import SessionDep
-from ...models.models import Alert
+from app.api.deps import SessionDep, validate_fk_exists
+from ...models.models import Alert, Event, Zone
 from ...models.schemas.alert import AlertCreate, AlertUpdate, AlertPublic, AlertsPublic
 
 alert_router = APIRouter()
@@ -52,6 +52,12 @@ def create_alert(alert_in: AlertCreate, session: SessionDep) -> AlertPublic:
     """
     Create a new alert.
     """
+    validate_fk_exists(session, Event, alert_in.event_id, "event_id")
+    validate_fk_exists(session, Zone, alert_in.zone_id, "zone_id")
+    validate_fk_exists(
+        session, Alert, alert_in.alert_is_suppressed_by, "alert_is_suppressed_by"
+    )
+
     alert = Alert.model_validate(alert_in)
     session.add(alert)
     session.commit()

--- a/backend/app/api/routes/event.py
+++ b/backend/app/api/routes/event.py
@@ -1,9 +1,9 @@
 from fastapi import APIRouter, HTTPException
 from typing import Optional, Literal
 from sqlmodel import select
-from ...models.models import Event
+from ...models.models import Event, Earthquake, Zone
 from ...models.schemas.event import EventCreate, EventUpdate, EventPublic, EventsPublic
-from app.api.deps import SessionDep
+from app.api.deps import SessionDep, validate_fk_exists
 
 event_router = APIRouter()
 
@@ -55,6 +55,9 @@ def create_event(event_in: EventCreate, session: SessionDep) -> EventPublic:
     """
     Create a new event.
     """
+    validate_fk_exists(session, Earthquake, event_in.earthquake_id, "earthquake_id")
+    validate_fk_exists(session, Zone, event_in.zone_id, "zone_id")
+
     event = Event.model_validate(event_in)
     session.add(event)
     session.commit()

--- a/backend/app/api/routes/report.py
+++ b/backend/app/api/routes/report.py
@@ -1,14 +1,14 @@
 from fastapi import APIRouter, HTTPException
 from typing import Optional, Literal
 from sqlmodel import select
-from ...models.models import Report
+from ...models.models import Report, Alert, User, Zone
 from ...models.schemas.report import (
     ReportCreate,
     ReportUpdate,
     ReportPublic,
     ReportsPublic,
 )
-from app.api.deps import SessionDep
+from app.api.deps import SessionDep, validate_fk_exists
 
 report_router = APIRouter()
 
@@ -62,6 +62,12 @@ def create_report(report_in: ReportCreate, session: SessionDep) -> ReportPublic:
     """
     Create a new report.
     """
+    validate_fk_exists(session, Alert, report_in.alert_id, "alert_id")
+    validate_fk_exists(session, User, report_in.user_id, "user_id")
+    validate_fk_exists(
+        session, Zone, report_in.report_factory_zone, "report_factory_zone"
+    )
+
     report = Report.model_validate(report_in)
     session.add(report)
     session.commit()


### PR DESCRIPTION
## Description
- add `validate_fk_exists()` function in `deps.py` and apply it to POST routes of `alert`, `event`, and `report`
- add tests for invalid fk scenarios

Issue related: https://github.com/kiwi-rikasa/ground-cow/issues/34

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Meta
- [ ] Refactor
- [ ] Chore
- [ ] Docs
- [ ] Style
- [x] Test
