### PR TITLE
fix(backend): restart id sequences from 0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up env
+        env:
+          ENV_FILE: ${{ secrets.ENV_FILE }}
         run: |
           cd ..
           touch .env
@@ -34,6 +36,8 @@ jobs:
           enable-cache: true
 
       - name: Init database and backend
+        env:
+          ENV_FILE: ${{ secrets.ENV_FILE }}
         run: |
           cd ..
           touch .env

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,12 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-      
+
       - name: Init database and backend
         run: |
           cd ..
+          touch .env
+          echo "${{ secrets.ENV_FILE }}" > .env
           docker compose down -v
           docker compose --profile backend up --build -d
 
@@ -78,4 +80,4 @@ jobs:
         with:
           name: frontend-build
           path: ./frontend/out
-          retention-days: 7 
+          retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
           cd ..
           touch .env
           echo "${{ secrets.ENV_FILE }}" > .env
+          ls -lah
+          cat .env
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -40,7 +42,8 @@ jobs:
           ENV_FILE: ${{ secrets.ENV_FILE }}
         run: |
           cd ..
-          touch .env
+          ls -lah
+          cat .env
           echo "${{ secrets.ENV_FILE }}" > .env
           docker compose down -v
           docker compose --profile backend up --build -d

--- a/backend/app/alembic/versions/686a24fbec57_restart_id_sequences_from_0.py
+++ b/backend/app/alembic/versions/686a24fbec57_restart_id_sequences_from_0.py
@@ -1,0 +1,56 @@
+"""restart_id_sequences_from_0
+
+Revision ID: 686a24fbec57
+Revises: 5099ba781ed1
+Create Date: 2025-05-15 16:32:40.577313
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "686a24fbec57"
+down_revision = "5099ba781ed1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER SEQUENCE zone_zone_id_seq MINVALUE 0;")
+    op.execute("ALTER SEQUENCE zone_zone_id_seq RESTART WITH 0;")
+
+    op.execute("ALTER SEQUENCE user_user_id_seq MINVALUE 0;")
+    op.execute("ALTER SEQUENCE user_user_id_seq RESTART WITH 0;")
+
+    op.execute("ALTER SEQUENCE earthquake_earthquake_id_seq MINVALUE 0;")
+    op.execute("ALTER SEQUENCE earthquake_earthquake_id_seq RESTART WITH 0;")
+
+    op.execute("ALTER SEQUENCE event_event_id_seq MINVALUE 0;")
+    op.execute("ALTER SEQUENCE event_event_id_seq RESTART WITH 0;")
+
+    op.execute("ALTER SEQUENCE alert_alert_id_seq MINVALUE 0;")
+    op.execute("ALTER SEQUENCE alert_alert_id_seq RESTART WITH 0;")
+
+    op.execute("ALTER SEQUENCE report_report_id_seq MINVALUE 0;")
+    op.execute("ALTER SEQUENCE report_report_id_seq RESTART WITH 0;")
+
+
+def downgrade():
+    op.execute("ALTER SEQUENCE zone_zone_id_seq MINVALUE 1;")
+    op.execute("ALTER SEQUENCE zone_zone_id_seq RESTART;")
+
+    op.execute("ALTER SEQUENCE user_user_id_seq MINVALUE 1;")
+    op.execute("ALTER SEQUENCE user_user_id_seq RESTART;")
+
+    op.execute("ALTER SEQUENCE earthquake_earthquake_id_seq MINVALUE 1;")
+    op.execute("ALTER SEQUENCE earthquake_earthquake_id_seq RESTART;")
+
+    op.execute("ALTER SEQUENCE event_event_id_seq MINVALUE 1;")
+    op.execute("ALTER SEQUENCE event_event_id_seq RESTART;")
+
+    op.execute("ALTER SEQUENCE alert_alert_id_seq MINVALUE 1;")
+    op.execute("ALTER SEQUENCE alert_alert_id_seq RESTART;")
+
+    op.execute("ALTER SEQUENCE report_report_id_seq MINVALUE 1;")
+    op.execute("ALTER SEQUENCE report_report_id_seq RESTART;")


### PR DESCRIPTION
## Description

Add Alembic migration to start ID sequences from 0.

Issue related: https://github.com/kiwi-rikasa/ground-cow/issues/54

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Meta
- [ ] Refactor
- [ ] Chore
- [ ] Docs
- [ ] Style
- [ ] Test
