### PR TITLE
feat(backend): include related foreign objects for GET endpoints

### DIFF
--- a/backend/app/models/schemas/alert.py
+++ b/backend/app/models/schemas/alert.py
@@ -3,6 +3,8 @@ from typing import Optional
 from sqlmodel import SQLModel, Field
 from ..consts import AlertState
 
+from app.models.schemas.zone import ZonePublic
+from app.models.schemas.event import EventPublic
 
 # Shared fields
 class AlertBase(SQLModel):
@@ -27,6 +29,8 @@ class AlertUpdate(SQLModel):
 # Response schema
 class AlertPublic(AlertBase):
     alert_id: int
+    zone: ZonePublic
+    event: EventPublic
     alert_created_at: datetime
 
 

--- a/backend/app/models/schemas/alert.py
+++ b/backend/app/models/schemas/alert.py
@@ -6,6 +6,7 @@ from ..consts import AlertState
 from app.models.schemas.zone import ZonePublic
 from app.models.schemas.event import EventPublic
 
+
 # Shared fields
 class AlertBase(SQLModel):
     event_id: int

--- a/backend/app/models/schemas/event.py
+++ b/backend/app/models/schemas/event.py
@@ -3,6 +3,9 @@ from typing import Optional
 from sqlmodel import SQLModel, Field
 from ..consts import EventSeverity
 
+from app.models.schemas.zone import ZonePublic
+from app.models.schemas.earthquake import EarthquakePublic
+
 
 # Shared fields
 class EventBase(SQLModel):
@@ -26,7 +29,9 @@ class EventUpdate(SQLModel):
 class EventPublic(EventBase):
     event_id: int
     earthquake_id: int
+    earthquake: EarthquakePublic
     zone_id: int
+    zone: ZonePublic
     event_created_at: datetime
 
 

--- a/backend/app/models/schemas/report.py
+++ b/backend/app/models/schemas/report.py
@@ -2,6 +2,9 @@ from datetime import datetime
 from typing import Optional
 from sqlmodel import SQLModel
 
+from app.models.schemas.user import UserPublic
+from app.models.schemas.alert import AlertPublic
+
 
 # Shared fields
 class ReportBase(SQLModel):
@@ -30,6 +33,8 @@ class ReportUpdate(SQLModel):
 # Response schema
 class ReportPublic(ReportBase):
     user_id: Optional[int] = None
+    user: Optional[UserPublic] = None
+    alert: Optional[AlertPublic] = None
     report_id: int
     report_created_at: datetime
 


### PR DESCRIPTION
## Description

Updated several API endpoints to include related objects (e.g. `User`, `Zone`) in responses by defining `Relationship` fields in models and applying `selectinload()` for eager loading. 

This allows clients to receive full related data instead of just foreign key IDs, improving efficiency and reducing the need for extra API calls.

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Meta
- [ ] Refactor
- [ ] Chore
- [ ] Docs
- [ ] Style
- [ ] Test
