### PR TITLE
feat(backend): add dashboard endpoints for zone and earthquake views

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -6,6 +6,7 @@ from .routes.alert import alert_router
 from .routes.event import event_router
 from .routes.zone import zone_router
 from .routes.report import report_router
+from .routes.dashboard import dashboard_router
 
 api_router = APIRouter()
 api_router.include_router(user_router, prefix="/user", tags=["user"])
@@ -15,6 +16,7 @@ api_router.include_router(alert_router, prefix="/alert", tags=["alert"])
 api_router.include_router(event_router, prefix="/event", tags=["event"])
 api_router.include_router(zone_router, prefix="/zone", tags=["zone"])
 api_router.include_router(report_router, prefix="/report", tags=["report"])
+api_router.include_router(dashboard_router, prefix="/dashboard", tags=["dashboard"])
 
 
 @api_router.get("/")

--- a/backend/app/api/routes/dashboard.py
+++ b/backend/app/api/routes/dashboard.py
@@ -1,0 +1,126 @@
+from fastapi import APIRouter, Depends
+from sqlmodel import select
+from sqlalchemy.orm import selectinload
+from datetime import datetime, timedelta
+from ...models.models import Earthquake, Event, Alert, Report, User
+from app.api.deps import SessionDep, require_session_user
+from ...services.dashboard import (
+    get_zone_stats,
+    get_zone_event_trend,
+    get_zone_histograms,
+    get_earthquake_stats,
+    get_earthquake_event_type,
+    get_earthquake_progress,
+)
+
+dashboard_router = APIRouter()
+
+
+@dashboard_router.get("/zone/{zone_id}")
+def get_zone_dashboard(
+    zone_id: int,
+    weeks: int,
+    session: SessionDep,
+    _: User = Depends(require_session_user),
+) -> dict:
+    """
+    Get dashoard data for selected zone.
+    """
+    now = datetime.now()
+    end = datetime.combine((now + timedelta(days=1)).date(), datetime.min.time())
+    start = end - timedelta(weeks=weeks)
+
+    events = session.exec(
+        select(Event)
+        .where(Event.zone_id == zone_id)
+        .where(Event.event_created_at.between(start, end))
+        .options(selectinload(Event.earthquake))
+    ).all()
+
+    alerts = session.exec(
+        select(Alert).where(Alert.event_id.in_([e.event_id for e in events]))
+    ).all()
+
+    reports = session.exec(
+        select(Report).where(Report.alert_id.in_([a.alert_id for a in alerts]))
+    ).all()
+
+    zone_stats = get_zone_stats(events, alerts, reports)
+    zone_event_trend = get_zone_event_trend(events, weeks)
+    zone_intensity_data, zone_magnitude_data = get_zone_histograms(events)
+
+    return {
+        "zoneStats": zone_stats,
+        "zoneEventTrend": zone_event_trend,
+        "zoneMagnitudeData": zone_magnitude_data,
+        "zoneIntensityData": zone_intensity_data,
+    }
+
+
+@dashboard_router.get("/earthquake")
+def get_filtered_earthquake_list(
+    session: SessionDep,
+    offset: int = 0,
+    limit: int = 30,
+    _: User = Depends(require_session_user),
+) -> dict:
+    """
+    List all earthquakes with at least one L1/L2 events.
+    """
+    subq = select(Event.earthquake_id).where(Event.event_severity != "NA").distinct()
+    filtered_ids = session.exec(subq).all()
+
+    earthquakes = session.exec(
+        select(Earthquake)
+        .where(Earthquake.earthquake_id.in_(filtered_ids))
+        .order_by(Earthquake.earthquake_occurred_at.desc())
+        .offset(offset)
+        .limit(limit)
+    ).all()
+
+    list_items = [
+        {
+            "id": eq.earthquake_id,
+            "label": f"{eq.earthquake_occurred_at.strftime('%Y-%m-%d %H:%M')} (M{round(eq.earthquake_magnitude, 1)})",
+        }
+        for eq in earthquakes
+    ]
+
+    return {"earthquakeList": list_items}
+
+
+@dashboard_router.get("/earthquake/{earthquake_id}")
+def get_earthquake_dashboard(
+    earthquake_id: int,
+    session: SessionDep,
+    _: User = Depends(require_session_user),
+) -> dict:
+    """
+    Get dashoard data for selected earthquake.
+    """
+    events = session.exec(
+        select(Event)
+        .where(Event.earthquake_id == earthquake_id)
+        .options(selectinload(Event.zone))
+    ).all()
+
+    if not events:
+        return {}
+
+    alerts = session.exec(
+        select(Alert).where(Alert.event_id.in_([e.event_id for e in events]))
+    ).all()
+
+    reports = session.exec(
+        select(Report).where(Report.alert_id.in_([a.alert_id for a in alerts]))
+    ).all()
+
+    earthquake_stats = get_earthquake_stats(events, alerts, reports)
+    earthquake_event_type = get_earthquake_event_type(events)
+    earthquake_progress = get_earthquake_progress(events, alerts)
+
+    return {
+        **earthquake_stats,
+        "earthquakeEventType": earthquake_event_type,
+        "earthquakeProgress": earthquake_progress,
+    }

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -1,0 +1,178 @@
+from typing import List, Tuple, Dict
+from collections import defaultdict
+from datetime import datetime, timedelta
+from ..models.models import Event, Alert, Report
+
+
+def get_zone_stats(
+    events: List[Event], alerts: List[Alert], reports: List[Report]
+) -> dict:
+    """
+    Summarize key indicators for a specific zone.
+    """
+    total_events = len(events)
+    action_rate = (
+        sum(r.report_action_flag for r in reports) / len(reports) if reports else 0
+    )
+    damage_rate = (
+        sum(r.report_damage_flag for r in reports) / len(reports) if reports else 0
+    )
+    alert_completion_rate = len(reports) / len(alerts) if alerts else 0
+    alert_suppression_rate = (
+        sum(1 for a in alerts if a.alert_is_suppressed_by) / len(alerts)
+        if alerts
+        else 0
+    )
+
+    alert_map = {a.alert_id: a for a in alerts}
+    total_response_time = sum(
+        (r.report_created_at - alert_map[r.alert_id].alert_created_at).total_seconds()
+        for r in reports
+        if r.alert_id in alert_map
+    )
+    avg_response_time = total_response_time / len(reports) if reports else 0
+
+    return {
+        "totalEvents": str(total_events),
+        "actionRate": f"{round(action_rate * 100)}%",
+        "damageRate": f"{round(damage_rate * 100)}%",
+        "alertCompletionRate": f"{round(alert_completion_rate * 100)}%",
+        "alertSuppressionRate": f"{round(alert_suppression_rate * 100)}%",
+        "avgResponseTime": f"{int(avg_response_time // 60)}m {int(avg_response_time % 60)}s",
+    }
+
+
+def get_zone_event_trend(events: List[Event], weeks: int) -> List[Dict]:
+    """
+    Generate weekly L1/L2 event trend data for the zone dashboard.
+    """
+    today = datetime.now().date()
+    trend = {}
+
+    week_starts = [
+        today - timedelta(days=7 * (i + 1) - 1) for i in reversed(range(weeks))
+    ]
+
+    for start in week_starts:
+        trend[start] = {"L1": 0, "L2": 0}
+
+    for e in events:
+        e_date = e.event_created_at.date()
+        for start in week_starts:
+            end = start + timedelta(days=6)
+            if start <= e_date <= end:
+                if e.event_severity == "L1":
+                    trend[start]["L1"] += 1
+                elif e.event_severity == "L2":
+                    trend[start]["L2"] += 1
+                break
+
+    def format_range(start_date):
+        end_date = start_date + timedelta(days=6)
+        return f"{start_date.month}/{start_date.day} - {end_date.month}/{end_date.day}"
+
+    return [{"date": format_range(week), **trend[week]} for week in sorted(trend)]
+
+
+def build_histogram(data: List[float], bins: List[Tuple[float, float]]) -> List[dict]:
+    """
+    Create histogram data from a list of values using predefined bins.
+    """
+    result = []
+    for low, high in bins:
+        label = f"{low}-{high}" if high != float("inf") else f"{low}+"
+        count = sum(low <= v < high for v in data)
+        result.append({"bin": label, "count": count})
+    return result
+
+
+def get_zone_histograms(events: List[Event]) -> Tuple[List[dict], List[dict]]:
+    """
+    Generate magnitude and intensity histograms for a list of events.
+    """
+    intensity_bins = [
+        (0.0, 1.0),
+        (1.0, 2.0),
+        (2.0, 3.0),
+        (3.0, 4.0),
+        (4.0, 5.0),
+        (5.0, 6.0),
+        (6.0, 7.0),
+    ]
+    magnitude_bins = [
+        (0.0, 2.0),
+        (2.0, 3.0),
+        (3.0, 4.0),
+        (4.0, 5.0),
+        (5.0, 6.0),
+        (6.0, 7.0),
+        (7.0, float("inf")),
+    ]
+
+    intensity_data = [e.event_intensity for e in events]
+    magnitude_data = [e.earthquake.earthquake_magnitude for e in events if e.earthquake]
+
+    return (
+        build_histogram(intensity_data, intensity_bins),
+        build_histogram(magnitude_data, magnitude_bins),
+    )
+
+
+def get_earthquake_stats(
+    events: List[Event], alerts: List[Alert], reports: List[Report]
+) -> Dict[str, str]:
+    """
+    Summarize key indicators for a specific earthquake.
+    """
+    e = events[0].earthquake
+    occurrence_time = e.earthquake_occurred_at.strftime("%Y-%m-%d %H:%M")
+    magnitude = round(e.earthquake_magnitude, 1)
+    intensity = max(ev.event_intensity for ev in events)
+
+    completion_rate = len(reports) / len(alerts) if alerts else 0
+    action_rate = (
+        sum(r.report_action_flag for r in reports) / len(reports) if reports else 0
+    )
+    damage_rate = (
+        sum(r.report_damage_flag for r in reports) / len(reports) if reports else 0
+    )
+
+    return {
+        "occurrenceTime": occurrence_time,
+        "magnitude": str(magnitude),
+        "maxIntensity": str(intensity),
+        "alertCompletionRate": f"{round(completion_rate * 100)}%",
+        "actionRate": f"{round(action_rate * 100)}%",
+        "damageRate": f"{round(damage_rate * 100)}%",
+    }
+
+
+def get_earthquake_event_type(events: List[Event]) -> List[Dict[str, int]]:
+    """
+    Count the number of L1 and L2 events for a specific earthquake.
+    """
+    counter = defaultdict(int)
+    for e in events:
+        if e.event_severity in ("L1", "L2"):
+            counter[e.event_severity] += 1
+    return [{"type": k, "count": v} for k, v in sorted(counter.items())]
+
+
+def get_earthquake_progress(
+    events: List[Event], alerts: List[Alert]
+) -> List[Dict[str, str]]:
+    """
+    List the alert state and severity for each zone affected by the earthquake.
+    """
+    alert_map = {a.event_id: a for a in alerts}
+    progress = []
+    for e in events:
+        a = alert_map.get(e.event_id)
+        progress.append(
+            {
+                "zone": e.zone.zone_name,
+                "severity": e.event_severity,
+                "state": a.alert_state,
+            }
+        )
+    return progress


### PR DESCRIPTION
## Description

Implements the zone and earthquake dashboard APIs, including:

- `GET /dashboard/zone/{zone_id}`:
  - Returns zone statistics, event trend (weekly), and magnitude/intensity histograms.
  - Filters events within the last N weeks, inclusive of today.

- `GET /dashboard/earthquake`:
  - Returns a list of formatted recent earthquakes.
  - Filters only earthquakes with at least one non-NA event.

- `GET /dashboard/earthquake/{earthquake_id}`:
  - Returns earthquake statistics, event type breakdown, and alert progress by zone.

Issue related: https://github.com/kiwi-rikasa/ground-cow/issues/79

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Meta
- [ ] Refactor
- [ ] Chore
- [ ] Docs
- [ ] Style
- [ ] Test
