### PR TITLE
feat(airflow): add simulation dag

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -16,6 +16,21 @@ This DAG runs every 30 seconds and orchestrates the following workflow:
 
 In this implementation, saving incidents (event + alert) is done sequentially by zone. This is because alert suppression requires data to be in time order.
 
+### Simulation DAG: `earthquake_simulator_dag`
+
+This DAG allows you to simulate earthquake events for testing purposes. You can provide a list of earthquake data (in JSON format) as a parameter, and the DAG will create corresponding earthquakes, events, and alerts at the time you specified.
+
+**Parameter format:**  
+The parameter should be a JSON array, where each item represents a simulated earthquake event. Each object must include:
+
+- `delta` (int): The number of seconds after the DAG is triggered when the earthquake should occur.
+- `earthquake` (object): The earthquake data, which **must be in the same format as a single CWA API response's `records.Earthquake[i]` object** (see the CWA API or real data for structure).
+
+> The `id`, `timestamp`, and `source` fields of each earthquake will be updated automatically by the simulator.
+
+**Note:**  
+The simulation DAG does not run on a schedule and must be triggered manually with input data.
+
 ### Zone Helper DAG: `zone_fetcher_dag`
 
 This DAG fetches zone data from the backend API and caches it in an Airflow Variable. The cache is refreshed every 10 minutes to keep data up to date and to reduce the number of main database queries.

--- a/airflow/dags/earthquake_simulator_dag.py
+++ b/airflow/dags/earthquake_simulator_dag.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+import json
+import time
+from datetime import datetime
+
+from airflow.decorators import dag, task, task_group
+from airflow.models.param import Param
+from airflow.utils.dates import days_ago
+
+from src.core.alert import Alert
+from src.core.equake import Earthquake
+from src.core.event import Event
+from src.core.simulation import SimulationData
+from src.core.zone import Zone
+from src.service.alert_service import save_alert, get_open_alert, set_open_alert
+from src.service.equake_service import save_earthquake as _save_earthquake
+from src.service.event_service import parse_event, save_event
+from src.service.interval_service import get_interval
+from src.service.zone_service import get_zones as _get_zones
+
+
+@dag(
+    dag_id="earthquake_simulator_dag",
+    schedule_interval=None,
+    start_date=days_ago(1),
+    catchup=False,
+    max_active_runs=1,
+    params={"data": Param("[]", type="string")},
+    tags=["zone"],
+)
+def earthquake_simulator_dag():
+    @task
+    def get_params(params: dict) -> list[any]:
+        return json.loads(params["data"])
+
+    @task
+    def get_zones() -> list[Zone]:
+        return _get_zones()
+
+    @task
+    def generate_earthquakes(data: list[dict]) -> list[Earthquake]:
+        return SimulationData.from_raw(data).earthquakes
+
+    @task
+    def wait_until_earthquake_occur(earthquake: Earthquake) -> None:
+        while datetime.now().timestamp() < earthquake.timestamp:
+            time.sleep(1)
+
+    @task
+    def save_earthquake(earthquake: Earthquake) -> Earthquake:
+        _save_earthquake(earthquake)
+        return earthquake
+
+    @task_group
+    def process_events(earthquake: Earthquake, zones: list[Zone]) -> list[Event]:
+        @task
+        def generate_events(earthquake: Earthquake, zones: list[Zone]) -> list[Event]:
+            events = [parse_event(earthquake, z) for z in zones]
+            return list(filter(None, events))
+
+        @task
+        def save_events(events: list[Event]) -> list[Event]:
+            for event in events:
+                event.id, _ = save_event(event)
+            return events
+
+        events = generate_events(earthquake, zones)
+        events = save_events(events)
+        return events
+
+    @task_group
+    def process_alerts(events: list[Event]) -> list[Alert]:
+        @task
+        def generate_alerts(events: list[Event]) -> list[Alert]:
+            alerts = [Alert.from_event(e, datetime.now().timestamp()) for e in events]
+            return alerts
+
+        @task
+        def save_alerts(alerts: list[Alert]) -> list[Alert]:
+            for alert in alerts:
+                prev_alert = get_open_alert(alert.zone_id)
+                interval = get_interval()
+                should_suppress = alert.should_be_suppressed_by(prev_alert, interval)
+                alert.suppressed_by = prev_alert.id if should_suppress else None
+                alert.id, _ = save_alert(alert)
+                if not should_suppress:
+                    set_open_alert(alert)
+            return alerts
+
+        alerts = generate_alerts(events)
+        alerts = save_alerts(alerts)
+        return alerts
+
+    @task_group
+    def simulate(earthquake: Earthquake, zones: list[Zone]):
+        _wait = wait_until_earthquake_occur(earthquake)
+        equake = save_earthquake(earthquake)
+        events = process_events(equake, zones)
+        alerts = process_alerts(events)
+
+        _wait >> equake >> events >> alerts
+
+    data = get_params()
+    zones = get_zones()
+    earthquakes = generate_earthquakes(data)
+
+    simulate.partial(zones=zones).expand(earthquake=earthquakes)
+
+
+earthquake_simulator_dag()

--- a/airflow/src/core/equake.py
+++ b/airflow/src/core/equake.py
@@ -34,10 +34,12 @@ class Earthquake:
         timestamp: int,
         magnitude: float,
         stations: list[Station],
+        source: str = "N/A",
     ):
         self.id = int(id)
         self.timestamp = int(timestamp)
         self.magnitude = float(magnitude)
+        self.source = source
         self.stations = stations
 
     @classmethod
@@ -46,6 +48,7 @@ class Earthquake:
             id=data.get("id"),
             timestamp=data.get("timestamp"),
             magnitude=data.get("magnitude"),
+            source=data.get("source"),
             stations=data.get("stations", []),
         )
 
@@ -54,6 +57,7 @@ class Earthquake:
             "id": self.id,
             "timestamp": self.timestamp,
             "magnitude": self.magnitude,
+            "source": self.source,
             "stations": self.stations,
         }
 

--- a/airflow/src/core/equake_parser.py
+++ b/airflow/src/core/equake_parser.py
@@ -33,6 +33,12 @@ class EarthquakeParser:
         except ValueError:
             return 0
 
+    def get_earthquake_source(self) -> str:
+        """
+        Returns the source of the earthquake data.
+        """
+        return self._entry.get("EarthquakeInfo", {}).get("Source", "N/A")
+
     def get_earthquake_magnitude(self) -> float:
         """
         Returns the magnitude of the earthquake.
@@ -60,6 +66,7 @@ class EarthquakeParser:
             id=parser.get_earthquake_id(),
             timestamp=parser.get_earthquake_timestamp(),
             magnitude=parser.get_earthquake_magnitude(),
+            source=parser.get_earthquake_source(),
             stations=[StationParser.parse(s) for s in parser.get_stations()],
         )
 

--- a/airflow/src/core/simulation.py
+++ b/airflow/src/core/simulation.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+from typing import TypedDict
+
+from src.core.equake import Earthquake
+from src.core.equake_parser import EarthquakeParser
+
+
+class SimulationEntry(TypedDict):
+    delta: int
+    earthquake: dict[str, any]
+
+
+class SimulationData:
+    def __init__(
+        self,
+        base_time: int = int(datetime.now().timestamp()),
+        earthquakes: list[Earthquake] = [],
+    ):
+        self.base_time = base_time
+        self.earthquakes = earthquakes
+
+    @staticmethod
+    def _apply_json_template(earthquake: dict[str, any]) -> dict[str, any]:
+        return {"records": {"Earthquake": [earthquake]}}
+
+    @staticmethod
+    def _reparse_id(earthquake: Earthquake) -> int:
+        dt = datetime.fromtimestamp(earthquake.timestamp)
+        id_time = dt.strftime("%Y%m%d%H%M%S")
+        id_magnitude = f"{earthquake.magnitude:.1f}".replace(".", "")
+        id_serial = 999
+        return int(f"{id_time}{id_magnitude}{id_serial}")
+
+    @classmethod
+    def from_raw(cls, entries: list[SimulationEntry] = []) -> "SimulationData":
+        base_time = int(datetime.now().timestamp())
+        earthquakes: list[Earthquake] = []
+
+        for re in entries:
+            # Apply the CWA JSON template to the earthquake data
+            earthquake_json = cls._apply_json_template(re["earthquake"])
+            # Parse the earthquake data
+            earthquake = EarthquakeParser.parse(earthquake_json)
+            # Set the new id, timestamp and source
+            earthquake.timestamp = base_time + re["delta"]
+            earthquake.id = cls._reparse_id(earthquake)
+            earthquake.source = "Simulation"
+            # Add the earthquake to the list
+            earthquakes.append(earthquake)
+
+        return cls(base_time=base_time, earthquakes=earthquakes)
+
+    def __len__(self):
+        return len(self.earthquakes)
+
+    def __getitem__(self, idx):
+        return self.earthquakes[idx]

--- a/airflow/src/data/equake_repository.py
+++ b/airflow/src/data/equake_repository.py
@@ -57,7 +57,7 @@ def save_earthquake(earthquake: Earthquake) -> tuple[int, dict]:
             "earthquake_id": earthquake.id,
             "earthquake_occurred_at": earthquake.timestamp,
             "earthquake_magnitude": earthquake.magnitude,
-            "earthquake_source": "CWA",
+            "earthquake_source": earthquake.source,
         }
         response = requests.post(
             EQUAKE_API_URL,

--- a/airflow/src/service/equake_service.py
+++ b/airflow/src/service/equake_service.py
@@ -13,7 +13,7 @@ def fetch_earthquakes() -> list[Earthquake]:
     return _fetch_earthquakes()
 
 
-def save_earthquake(earthquake) -> tuple[int, dict]:
+def save_earthquake(earthquake: Earthquake) -> tuple[int, dict]:
     return _save_earthquake(earthquake)
 
 


### PR DESCRIPTION
## Description

Added a simulation DAG for testing purposes.

Users can manually trigger this DAG with custom parameters, specifying the details and timing of each earthquake to be simulated. The DAG will then generate the corresponding earthquakes, events, and alerts.

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Meta
- [ ] Refactor
- [ ] Chore
- [ ] Docs
- [ ] Style
- [ ] Test
